### PR TITLE
SaveSTL: use buffered writer

### DIFF
--- a/sdf/stl.go
+++ b/sdf/stl.go
@@ -9,6 +9,7 @@ STL Load/Save
 package sdf
 
 import (
+	"bufio"
 	"encoding/binary"
 	"os"
 )
@@ -33,15 +34,17 @@ func SaveSTL(path string, mesh *Mesh) error {
 		return err
 	}
 	defer file.Close()
+
+	buf := bufio.NewWriter(file)
 	header := STLHeader{}
 	header.Count = uint32(len(mesh.Triangles))
-	if err := binary.Write(file, binary.LittleEndian, &header); err != nil {
+	if err := binary.Write(buf, binary.LittleEndian, &header); err != nil {
 		return err
 	}
 
+	var d STLTriangle
 	for _, triangle := range mesh.Triangles {
 		n := triangle.Normal()
-		d := STLTriangle{}
 		d.Normal[0] = float32(n.X)
 		d.Normal[1] = float32(n.Y)
 		d.Normal[2] = float32(n.Z)
@@ -54,12 +57,12 @@ func SaveSTL(path string, mesh *Mesh) error {
 		d.Vertex3[0] = float32(triangle.V[2].X)
 		d.Vertex3[1] = float32(triangle.V[2].Y)
 		d.Vertex3[2] = float32(triangle.V[2].Z)
-		if err := binary.Write(file, binary.LittleEndian, &d); err != nil {
+		if err := binary.Write(buf, binary.LittleEndian, &d); err != nil {
 			return err
 		}
 	}
 
-	return nil
+	return buf.Flush()
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
First and foremost, thank you for this awesome library! It's already supplanted OpenSCAD for a few of my latest parts!

Anyway, I've been working on ways to speed up rendering, so this may be the first of at least two PRs (the other being parallel processing).

What I found was that with the large number of triangles being encoded to generate the STL file: each call to `binary.Write` results in a blocking syscall. It ends up being a bunch of overhead, especially for high resolution renders.

This PR wraps the output file with a buffered writer while encoding, dramatically reducing the number of blocking calls. A small change, but with drastic results (in my case at least):

# Before
![before](https://user-images.githubusercontent.com/595010/36624679-d04e9300-18d7-11e8-9537-0d523cde20a2.png)

# After
![after](https://user-images.githubusercontent.com/595010/36624680-d3772f56-18d7-11e8-8fbf-d5c6d5d5ae5e.png)
