### PR TITLE
add temporary test script

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,20 @@
+ #!/bin/bash
+
+ # this is a temporary hack to be used until we create more complete
+ # *_test.go files 
+
+ # first run the tests we do have (may want to add coverage flags later)
+ cd sdf
+ go test
+ cd -
+ 
+ # then run all the examples (this takes a while)
+ time for d in examples/*
+ do 
+    echo $d
+    cd $d
+    make || exit 1
+    ./$(basename $d) || exit 1
+    make clean
+    cd -
+ done


### PR DESCRIPTION
This is a temporary test script some of us have been using to exercise both the ./sdf/sdf_test.go cases as well as all of the examples while we have been cleaning up the panics and error returns mentioned in #22 and #24.

I expect we'll replace this script with idiomatic Go *_test.go cases as we refactor the API in #22.