### PR TITLE
ensure 'make test' abends when any example fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,16 +42,16 @@ DIRS = 3dp_nutbolt \
 
 all:
 	for dir in $(DIRS); do \
-		$(MAKE) -C ./examples/$$dir $@; \
+		$(MAKE) -C ./examples/$$dir $@ || exit 1; \
 	done
 
 test:
 	cd sdf; go test; cd ..
 	for dir in $(DIRS); do \
-		$(MAKE) -C ./examples/$$dir $@; \
+		$(MAKE) -C ./examples/$$dir $@ || exit 1; \
 	done
 
 clean:
 	for dir in $(DIRS); do \
-		$(MAKE) -C ./examples/$$dir $@; \
+		$(MAKE) -C ./examples/$$dir $@ || exit 1; \
 	done


### PR DESCRIPTION
While working #24 and #28, we realized that make would happily keep cruising along when an example fails to build or execute.  ;-)  This fixes that.