### PR TITLE
Multithreaded Render3 implementation, parallelizing any other Render3 implementation.

### DIFF
--- a/examples/cylinder_head/main.go
+++ b/examples/cylinder_head/main.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/deadsy/sdfx/sdf"
 	"log"
 	"math"
+	"runtime"
 	"time"
 )
 
@@ -400,7 +401,10 @@ func subtractive() SDF3 {
 
 func main() {
 	s := Difference3D(additive(), subtractive())
-	render.RenderSTL(s, 400, "head.stl")
+
+	mtRenderer := render.NewMtRenderer3(&render.MarchingCubesUniform{}, 0)
+	mtRenderer.AutoSplitsMinimum(runtime.NumCPU())
+	render.ToSTL(s, 400, "head.stl", mtRenderer)
 	t1 := time.Now()
 	render.ToSTL(s, 128, "head2.stl", dc.NewDualContouringV1(-1, 0, false))
 	t2 := time.Now()
@@ -408,6 +412,12 @@ func main() {
 	td2 := time.Since(t2)
 	td1 := t2.Sub(t1)
 	log.Println("DualContouringV1 delta time:", td1, "- DualContouringDefault delta time:", td2)
+	mtRenderer2 := render.NewMtRenderer3(dc.NewDualContouringDefault(), 1)
+	mtRenderer2.AutoSplitsMinimum(runtime.NumCPU())
+	t3 := time.Now()
+	render.ToSTL(s, 128, "head2.stl", mtRenderer2)
+	td3 := time.Since(t3)
+	log.Println("DualContouringDefault delta time:", td2, "- DualContouringDefault MT delta time:", td3)
 }
 
 //-----------------------------------------------------------------------------

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/ajstarks/svgo v0.0.0-20200725142600-7a3c8b57fecb
+	github.com/barkimedes/go-deepcopy v0.0.0-20200817023428-a044a1957ca4
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
 	github.com/llgcode/draw2d v0.0.0-20200930101115-bfaf5d914d1e
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/ajstarks/svgo v0.0.0-20200725142600-7a3c8b57fecb h1:EVl3FJLQCzSbgBezKo/1A4ADnJ4mtJZ0RvnNzDJ44nY=
 github.com/ajstarks/svgo v0.0.0-20200725142600-7a3c8b57fecb/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
+github.com/barkimedes/go-deepcopy v0.0.0-20200817023428-a044a1957ca4 h1:iBbhlt5YmtL9QXsMVf/XPXgYBQLifn38Cdjc0J/+uYg=
+github.com/barkimedes/go-deepcopy v0.0.0-20200817023428-a044a1957ca4/go.mod h1:hiVxq5OP2bUGBRNS3Z/bt/reCLFNbdcST6gISi1fiOM=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/render/dc/dc3v1.go
+++ b/render/dc/dc3v1.go
@@ -14,7 +14,6 @@ Based on: https://github.com/nickgildea/DualContouringSample
 package dc
 
 import (
-	"fmt"
 	"github.com/deadsy/sdfx/render"
 	"github.com/deadsy/sdfx/sdf"
 	"gonum.org/v1/gonum/mat"
@@ -43,12 +42,8 @@ func NewDualContouringV1(simplify float64, RCond float64, lockVertices bool) *Du
 	return &DualContouringV1{Simplify: simplify, RCond: RCond, LockVertices: lockVertices}
 }
 
-// Info returns a string describing the rendered volume.
-func (m *DualContouringV1) Info(s sdf.SDF3, meshCells int) string {
-	bbSize := s.BoundingBox().Size()
-	resolution := bbSize.MaxComponent() / float64(meshCells)
-	cells := bbSize.DivScalar(resolution).ToV3i()
-	return fmt.Sprintf("%dx%dx%d, resolution %.2f", cells[0], cells[1], cells[2], resolution)
+func (m *DualContouringV1) Cells(s sdf.SDF3, meshCells int) (float64, sdf.V3i) {
+	return render.DefaultRender3Cells(s, meshCells)
 }
 
 // Render produces a 3d triangle mesh over the bounding volume of an sdf3.

--- a/render/dc/dc3v2.go
+++ b/render/dc/dc3v2.go
@@ -66,24 +66,22 @@ func NewDualContouringV2(farAway float64, centerPush float64, raycastScaleAndSig
 
 // Info returns a string describing the rendered volume.
 func (dc *DualContouringV2) Info(s sdf.SDF3, meshCells int) string {
-	resolution, cells := dc.getCells(s, meshCells)
+	resolution, cells := dc.Cells(s, meshCells)
 	return fmt.Sprintf("%dx%dx%d, resolution %.2f", cells[0], cells[1], cells[2], resolution)
 }
 
 // Render produces a 3d triangle mesh over the bounding volume of an sdf3.
 func (dc *DualContouringV2) Render(s sdf.SDF3, meshCells int, output chan<- *render.Triangle3) {
 	// Place one vertex for each cellIndex
-	_, cells := dc.getCells(s, meshCells)
+	_, cells := dc.Cells(s, meshCells)
 	s2 := &dcSdf{s, map[sdf.V3]float64{}}
 	vertexBuffer, vertexVoxelInfo, vertexVoxelInfoIndexed := dc.placeVertices(s2, cells)
 	// Stitch vertices together generating triangles
 	dc.generateTriangles(s2, vertexBuffer, vertexVoxelInfo, vertexVoxelInfoIndexed, output)
 }
 
-func (dc *DualContouringV2) getCells(s sdf.SDF3, meshCells int) (float64, sdf.V3i) {
-	bbSize := s.BoundingBox().Size()
-	resolution := bbSize.MaxComponent() / float64(meshCells)
-	return resolution, bbSize.DivScalar(resolution).ToV3i()
+func (dc *DualContouringV2) Cells(s sdf.SDF3, meshCells int) (float64, sdf.V3i) {
+	return render.DefaultRender3Cells(s, meshCells)
 }
 
 //-----------------------------------------------------------------------------
@@ -215,7 +213,7 @@ func (dc *DualContouringV2) placeVertex(s *dcSdf, cellStart, cellCenter, cellSiz
 			dc.RaycastEpsilon, dirLength*2, dc.RaycastMaxSteps)
 		if t < 0 || t > dirLength {
 			if !dc.raycastFailedWarned {
-				log.Println("[DualContouringV1] WARNING: raycast failed (steps:", steps, "- try modifying options), using fallback low accuracy implementation")
+				log.Println("[DualContouring] WARNING: raycast failed (steps:", steps, "- try modifying options), using fallback low accuracy implementation")
 				dc.raycastFailedWarned = true
 			}
 			edgeSurfPos = dcApproximateZeroCrossingPosition(s, cornerPos1, cornerPos2)
@@ -247,7 +245,7 @@ func (dc *DualContouringV2) placeVertex(s *dcSdf, cellStart, cellCenter, cellSiz
 	// Check if vertex positioning failed
 	if math.IsInf(vertexPos.X, 0) {
 		if !dc.qefFailedWarned {
-			log.Println("[DualContouringV1] WARNING: vertex positioning failed, centering vertex position!")
+			log.Println("[DualContouring] WARNING: vertex positioning failed, centering vertex position!")
 			dc.qefFailedWarned = true
 		}
 		vertexPos = cellCenter
@@ -258,7 +256,7 @@ func (dc *DualContouringV2) placeVertex(s *dcSdf, cellStart, cellCenter, cellSiz
 		math.Abs(vertexPos.Y-cellCenter.Y) > dc.FarAway*cellSize.Y ||
 		math.Abs(vertexPos.Z-cellCenter.Z) > dc.FarAway*cellSize.Z {
 		if !dc.farAwayWarned {
-			log.Print("[DualContouringV1] WARNING: generated a vertex two far away from voxel (by ",
+			log.Print("[DualContouring] WARNING: generated a vertex two far away from voxel (by ",
 				vertexPos.Sub(cellCenter), ", from ", cellCenter, " to ", vertexPos, "), clamping vertex position!\n")
 			dc.farAwayWarned = true
 		}
@@ -312,7 +310,8 @@ func (dc *DualContouringV2) generateTriangles(s *dcSdf, vertices []sdf.V3, info 
 
 			if v1 == nil || v2 == nil || v3 == nil { // Shouldn't ever happen
 				if !dc.faceVertexNotFoundWarned {
-					log.Println("[DualContouringV1] WARNING: no vertex found for completing face, there will be holes")
+					log.Println("[DualContouring] WARNING: no vertex found for completing face, there will be holes " +
+						"(this happens if the surface crosses the bounding box)")
 					dc.faceVertexNotFoundWarned = true
 				}
 				continue
@@ -361,7 +360,7 @@ func (dc *DualContouringV2) computeVertexPos(normals []sdf.V3, planeDs []float64
 	//err := res.Solve(A, b)
 	//if err != nil {
 	//	if !dc.qefFailedImplWarned {
-	//		log.Println("[DualContouringV1] WARNING: QEF solver failed: ", err.Error())
+	//		log.Println("[DualContouring] WARNING: QEF solver failed: ", err.Error())
 	//		dc.qefFailedImplWarned = true
 	//	}
 	//	return sdf.V3{X: math.Inf(1)}

--- a/render/march3.go
+++ b/render/march3.go
@@ -11,7 +11,6 @@ Convert an SDF3 to a triangle mesh.
 package render
 
 import (
-	"fmt"
 	"math"
 	"runtime"
 	"sync"
@@ -264,15 +263,8 @@ func mcInterpolate(p1, p2 sdf.V3, v1, v2, x float64) sdf.V3 {
 type MarchingCubesUniform struct {
 }
 
-// Info returns a string describing the rendered volume.
-func (m *MarchingCubesUniform) Info(s sdf.SDF3, meshCells int) string {
-	bb0 := s.BoundingBox()
-	bb0Size := bb0.Size()
-	meshInc := bb0Size.MaxComponent() / float64(meshCells)
-	bb1Size := bb0Size.DivScalar(meshInc)
-	bb1Size = bb1Size.Ceil().AddScalar(1)
-	cells := bb1Size.ToV3i()
-	return fmt.Sprintf("%dx%dx%d", cells[0], cells[1], cells[2])
+func (m *MarchingCubesUniform) Cells(s sdf.SDF3, meshCells int) (float64, sdf.V3i) {
+	return DefaultRender3Cells(s, meshCells)
 }
 
 // Render produces a 3d triangle mesh over the bounding volume of an sdf3.
@@ -282,7 +274,7 @@ func (m *MarchingCubesUniform) Render(s sdf.SDF3, meshCells int, output chan<- *
 	bb0Size := bb0.Size()
 	meshInc := bb0Size.MaxComponent() / float64(meshCells)
 	bb1Size := bb0Size.DivScalar(meshInc)
-	bb1Size = bb1Size.Ceil().AddScalar(1)
+	bb1Size = bb1Size /*.Ceil().AddScalar(1) - Changed to work with multithread renderer: same behaviour as other renderers*/
 	bb1Size = bb1Size.MulScalar(meshInc)
 	bb := sdf.NewBox3(bb0.Center(), bb1Size)
 	for _, tri := range marchingCubes(s, bb, meshInc) {

--- a/render/march3x.go
+++ b/render/march3x.go
@@ -12,7 +12,6 @@ Uses octree space subdivision.
 package render
 
 import (
-	"fmt"
 	"math"
 	"sync"
 
@@ -159,12 +158,8 @@ func marchingCubesOctree(s sdf.SDF3, resolution float64, output chan<- *Triangle
 type MarchingCubesOctree struct {
 }
 
-// Info returns a string describing the rendered volume.
-func (m *MarchingCubesOctree) Info(s sdf.SDF3, meshCells int) string {
-	bbSize := s.BoundingBox().Size()
-	resolution := bbSize.MaxComponent() / float64(meshCells)
-	cells := bbSize.DivScalar(resolution).ToV3i()
-	return fmt.Sprintf("%dx%dx%d, resolution %.2f", cells[0], cells[1], cells[2], resolution)
+func (m *MarchingCubesOctree) Cells(s sdf.SDF3, meshCells int) (float64, sdf.V3i) {
+	return DefaultRender3Cells(s, meshCells)
 }
 
 // Render produces a 3d triangle mesh over the bounding volume of an sdf3.

--- a/render/multithread3.go
+++ b/render/multithread3.go
@@ -1,0 +1,112 @@
+//-----------------------------------------------------------------------------
+/*
+
+Multithreaded 3D renderer
+
+*/
+//-----------------------------------------------------------------------------
+
+package render
+
+import (
+	"github.com/barkimedes/go-deepcopy"
+	"github.com/deadsy/sdfx/sdf"
+	"math"
+	"sync"
+)
+
+// MTRenderer3 converts a SDF3 to a triangle mesh, parallelizing the rendering process by splitting the space.
+// It supports MarchingCubesUniform and dc.DualContouringV2 (not MarchingCubesOctree for some reason),
+// and should support other Render3 voxel-based implementation.
+type MTRenderer3 struct {
+	// impl the base implementation to copy and use for rendering partial surfaces.
+	impl Render3
+	// NumSplits is the number of times to split each dimension (0 splits means 1 partition).
+	NumSplits sdf.V3i
+	// OverlappingCells provides overlapping boundaries so that N cells are shared between contiguous renderers.
+	// Set to 0 for Marching Cubes renderer and to 1 for Dual Contouring (places vertices instead of faces per voxel)
+	OverlappingCells float64
+}
+
+var _ Render3 = &MTRenderer3{}
+
+// NewMtRenderer3 see MTRenderer3
+func NewMtRenderer3(impl Render3, overlappingCells float64) *MTRenderer3 {
+	return &MTRenderer3{impl: impl, OverlappingCells: overlappingCells, NumSplits: sdf.V3i{0, 0, 0}}
+}
+
+// AutoSplitsMinimum auto-partitions the space to have at least `routines` partitions.
+//
+// Example: `MTRenderer3.AutoSplitsMinimum(runtime.NumCPU())`
+func (m *MTRenderer3) AutoSplitsMinimum(minPartitions int) {
+	// Try to share splits in all dimensions, forcing last dimension to get more splits if needed (may overshoot `minPartitions`)
+	splits := float64(minPartitions) * math.Pow(2, -3 /* dimensions */)
+	m.NumSplits = sdf.V3i{int(splits), int(splits), int(splits)}
+	// If more splits are needed, give the first dimension more splits (generate at least minPartitions splits)
+	// NOTE: partitions = splits + 1
+	m.NumSplits[0] += (minPartitions - (m.NumSplits[0]+1)*(m.NumSplits[1]+1)*(m.NumSplits[2]+1)) /
+		((m.NumSplits[1] + 1) * (m.NumSplits[2] + 1))
+}
+
+func (m *MTRenderer3) Cells(sdf3 sdf.SDF3, meshCells int) (float64, sdf.V3i) {
+	return m.impl.Cells(sdf3, meshCells)
+}
+
+func (m *MTRenderer3) Render(sdf3 sdf.SDF3, meshCells int, output chan<- *Triangle3) {
+	// Get cells to render on each dimension (change Render3 Info)
+	originalResolution, originalCells := m.Cells(sdf3, meshCells)
+	fullBb := sdf3.BoundingBox()
+	fullBbSize := fullBb.Size()
+	cellSize := fullBbSize.Div(originalCells.ToV3())
+	numPartitions := m.NumSplits.AddScalar(1)
+
+	// The priority is to keep the cellSize the same on all partitions (in case overlapping cells are needed)
+	// Then, try to have all partitions be of the same size to avoid waiting for one goroutine to finish
+	cellsPerPartitionBase := originalCells.ToV3().Div(numPartitions.ToV3())
+	partitionSizeBase := cellSize.Mul(cellsPerPartitionBase)
+	partitionSize := cellSize.Mul(cellsPerPartitionBase.AddScalar(m.OverlappingCells))
+	subMeshCells := int( /*math.Ceil*/ partitionSize.MaxComponent() / originalResolution)
+
+	cellIndex := sdf.V3i{0, 0, 0}
+	wg := &sync.WaitGroup{}
+	for cellIndex[0] = 0; cellIndex[0] <= m.NumSplits[0]; cellIndex[0]++ {
+		for cellIndex[1] = 0; cellIndex[1] <= m.NumSplits[1]; cellIndex[1]++ {
+			for cellIndex[2] = 0; cellIndex[2] <= m.NumSplits[2]; cellIndex[2]++ {
+				// Get bounded sub-surface
+				// WARNING: Will be slightly outside the original bounding-box (for simplicity, if OverlappingCells > 0),
+				// but keeps partition size and cells per partition the same so that OverlappingCells works
+				from := fullBb.Min.Add(partitionSizeBase.Mul(cellIndex.ToV3())).AddScalar(-m.OverlappingCells / 2)
+				to := from.Add(partitionSize)
+				subSurface := &customBbSdf{impl: sdf3, bb: sdf.Box3{Min: from, Max: to}}
+				// Spawn the rendering goroutine
+				go func(impl Render3, subSurface sdf.SDF3) {
+					// Debug
+					//resolution2, cells2 := impl.Cells(subSurface, subMeshCells)
+					//fmt.Printf("rendering part (%dx%dx%d, resolution %.2f) from %s to %s\n",
+					//	cells2[0], cells2[1], cells2[2], resolution2, fmt.Sprint(subSurface.BoundingBox().Min),
+					//	fmt.Sprint(subSurface.BoundingBox().Max))
+					// Just call render on the sub-surface, generating triangles to the same output
+					impl.Render(subSurface, subMeshCells, output)
+					wg.Done()
+				}(deepcopy.MustAnything(m.impl).(Render3), subSurface)
+				wg.Add(1)
+			}
+		}
+	}
+	wg.Wait() // Wait for all spawned goroutines (space partition renderers) to finish
+}
+
+var _ sdf.SDF3 = &customBbSdf{}
+
+type customBbSdf struct {
+	impl sdf.SDF3
+	bb   sdf.Box3
+}
+
+func (m *customBbSdf) Evaluate(p sdf.V3) float64 {
+	return m.impl.Evaluate(p)
+}
+
+func (m *customBbSdf) BoundingBox() sdf.Box3 {
+	return m.bb
+}


### PR DESCRIPTION
The new MTRenderer3 is capable of parallelizing the generation of a surface by splitting the space into partitions and running any other Render3 implementation in each of those at the same time.

It works with Marching Cubes Uniform (overlappingCells: 0) and Dual Contouring (overlappingCells: 1). I don't know why Marching Cubes Octree does not work (it sometimes creates the whole surface ignoring the bounding box).

It achieves up to x7.3 speedup using my 12 cores (6 physical cores, tested on cylinder_head with Dual Contouring and a total of 256 meshCells).

Demo of automatic space partition (calling `MTRenderer3.AutoSplitsMinimum(12)` generates these 12 partitions):

![Screenshot_20211230_001620](https://user-images.githubusercontent.com/4929005/147710023-e0227169-7324-4a20-8a64-bbcd740a415e.png)

The final output doesn't have holes:

![Screenshot_20211230_001231](https://user-images.githubusercontent.com/4929005/147710012-16b90223-d7f8-4270-8ec7-eea36cdcd3e2.png)


