### PR TITLE
add slice render method

### DIFF
--- a/render/march3x.go
+++ b/render/march3x.go
@@ -133,6 +133,41 @@ func (dc *dcache3) processCube(c *cube, output chan<- *Triangle3) {
 	}
 }
 
+// Process a cube. Generate triangles, or more cubes.
+func (dc *dcache3) processCubeSlice(c *cube) (output []Triangle3) {
+	if !dc.isEmpty(c) {
+		if c.n == 1 {
+			// this cube is at the required resolution
+			c0, d0 := dc.evaluate(c.v.Add(sdf.V3i{0, 0, 0}))
+			c1, d1 := dc.evaluate(c.v.Add(sdf.V3i{2, 0, 0}))
+			c2, d2 := dc.evaluate(c.v.Add(sdf.V3i{2, 2, 0}))
+			c3, d3 := dc.evaluate(c.v.Add(sdf.V3i{0, 2, 0}))
+			c4, d4 := dc.evaluate(c.v.Add(sdf.V3i{0, 0, 2}))
+			c5, d5 := dc.evaluate(c.v.Add(sdf.V3i{2, 0, 2}))
+			c6, d6 := dc.evaluate(c.v.Add(sdf.V3i{2, 2, 2}))
+			c7, d7 := dc.evaluate(c.v.Add(sdf.V3i{0, 2, 2}))
+			corners := [8]sdf.V3{c0, c1, c2, c3, c4, c5, c6, c7}
+			values := [8]float64{d0, d1, d2, d3, d4, d5, d6, d7}
+			// output the triangle(s) for this cube
+			output = append(output, mcToTrianglesSlice(corners, values, 0)...)
+		} else {
+			// process the sub cubes
+			n := c.n - 1
+			s := 1 << n
+			// TODO - turn these into throttled go-routines
+			output = append(output, dc.processCubeSlice(&cube{c.v.Add(sdf.V3i{0, 0, 0}), n})...)
+			output = append(output, dc.processCubeSlice(&cube{c.v.Add(sdf.V3i{s, 0, 0}), n})...)
+			output = append(output, dc.processCubeSlice(&cube{c.v.Add(sdf.V3i{s, s, 0}), n})...)
+			output = append(output, dc.processCubeSlice(&cube{c.v.Add(sdf.V3i{0, s, 0}), n})...)
+			output = append(output, dc.processCubeSlice(&cube{c.v.Add(sdf.V3i{0, 0, s}), n})...)
+			output = append(output, dc.processCubeSlice(&cube{c.v.Add(sdf.V3i{s, 0, s}), n})...)
+			output = append(output, dc.processCubeSlice(&cube{c.v.Add(sdf.V3i{s, s, s}), n})...)
+			output = append(output, dc.processCubeSlice(&cube{c.v.Add(sdf.V3i{0, s, s}), n})...)
+		}
+	}
+	return output
+}
+
 //-----------------------------------------------------------------------------
 
 // marchingCubesOctree generates a triangle mesh for an SDF3 using octree subdivision.
@@ -151,6 +186,23 @@ func marchingCubesOctree(s sdf.SDF3, resolution float64, output chan<- *Triangle
 	dc := newDcache3(s, bb.Min, resolution, levels)
 	// process the octree, start at the top level
 	dc.processCube(&cube{sdf.V3i{0, 0, 0}, levels - 1}, output)
+}
+
+func marchingCubesOctreeSlice(s sdf.SDF3, resolution float64) []Triangle3 {
+	// Scale the bounding box about the center to make sure the boundaries
+	// aren't on the object surface.
+	bb := s.BoundingBox()
+	bb = bb.ScaleAboutCenter(1.01)
+	longAxis := bb.Size().MaxComponent()
+	// We want to test the smallest cube (side == resolution) for emptiness
+	// so the level = 0 cube is at half resolution.
+	resolution = 0.5 * resolution
+	// how many cube levels for the octree?
+	levels := uint(math.Ceil(math.Log2(longAxis/resolution))) + 1
+	// create the distance cache
+	dc := newDcache3(s, bb.Min, resolution, levels)
+	// process the octree, start at the top level
+	return dc.processCubeSlice(&cube{sdf.V3i{0, 0, 0}, levels - 1})
 }
 
 //-----------------------------------------------------------------------------
@@ -173,6 +225,14 @@ func (m *MarchingCubesOctree) Render(s sdf.SDF3, meshCells int, output chan<- *T
 	bbSize := s.BoundingBox().Size()
 	resolution := bbSize.MaxComponent() / float64(meshCells)
 	marchingCubesOctree(s, resolution, output)
+}
+
+// Render produces a 3d triangle mesh over the bounding volume of an sdf3.
+func (m *MarchingCubesOctree) RenderSlice(s sdf.SDF3, meshCells int) []Triangle3 {
+	// work out the sampling resolution to use
+	bbSize := s.BoundingBox().Size()
+	resolution := bbSize.MaxComponent() / float64(meshCells)
+	return marchingCubesOctreeSlice(s, resolution)
 }
 
 //-----------------------------------------------------------------------------

--- a/render/render.go
+++ b/render/render.go
@@ -33,7 +33,7 @@ func ToSTL(
 	fmt.Printf("rendering %s (%s)\n", path, r.Info(s, meshCells))
 	// write the triangles to an STL file
 	var wg sync.WaitGroup
-	output, err := WriteSTL(&wg, path)
+	output, err := StreamSTL(&wg, path)
 	if err != nil {
 		fmt.Printf("%s", err)
 		return

--- a/render/stl.go
+++ b/render/stl.go
@@ -33,7 +33,7 @@ type STLTriangle struct {
 //-----------------------------------------------------------------------------
 
 // SaveSTL writes a triangle mesh to an STL file.
-func SaveSTL(path string, mesh []*Triangle3) error {
+func SaveSTL(path string, mesh []Triangle3) error {
 	file, err := os.Create(path)
 	if err != nil {
 		return err
@@ -72,8 +72,8 @@ func SaveSTL(path string, mesh []*Triangle3) error {
 
 //-----------------------------------------------------------------------------
 
-// WriteSTL writes a stream of triangles to an STL file.
-func WriteSTL(wg *sync.WaitGroup, path string) (chan<- *Triangle3, error) {
+// StreamSTL writes a stream of triangles to an STL file.
+func StreamSTL(wg *sync.WaitGroup, path string) (chan<- *Triangle3, error) {
 
 	f, err := os.Create(path)
 	if err != nil {

--- a/render/stl_test.go
+++ b/render/stl_test.go
@@ -1,0 +1,60 @@
+package render_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/deadsy/sdfx/obj"
+	"github.com/deadsy/sdfx/render"
+	"github.com/deadsy/sdfx/sdf"
+)
+
+const (
+	tol     = .1
+	quality = 200
+)
+
+var (
+	renderer = &render.MarchingCubesOctree{}
+	object   sdf.SDF3
+)
+
+func init() {
+	boltParms := obj.BoltParms{
+		Thread:      "M16x2",
+		Style:       "hex",
+		Tolerance:   tol,
+		TotalLength: 50.0,
+		ShankLength: 10.0,
+	}
+	bolt, err := obj.Bolt(&boltParms)
+	if err != nil {
+		panic(err)
+	}
+	object = bolt
+}
+
+func BenchmarkSaveSTL(b *testing.B) {
+	const path = "bolt_save.stl"
+	// defer os.Remove(path)
+	for i := 0; i < b.N; i++ {
+		output := renderer.RenderSlice(object, quality)
+		err := render.SaveSTL(path, output)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkStreamSTL(b *testing.B) {
+	const path = "bolt_stream.stl"
+	// defer os.Remove(path)
+	for i := 0; i < b.N; i++ {
+		var wg sync.WaitGroup
+		ch, err := render.StreamSTL(&wg, path)
+		if err != nil {
+			b.Fatal(err)
+		}
+		renderer.Render(object, quality, ch)
+	}
+}


### PR DESCRIPTION
Octree rendering got almost a x2 speed boost. With a little creative freedom I'd offer rewriting the STL part of the `render` package as it seems to be lush with room for improvement, both speed and API thoughtfulness such as adding io.Writer convention, minimizing heap usage, and more.

```
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -coverprofile=/tmp/vscode-go3I2Mcj/go-code-cover -bench . github.com/deadsy/sdfx/render

goos: linux
goarch: amd64
pkg: github.com/deadsy/sdfx/render
cpu: AMD Ryzen 5 3400G with Radeon Vega Graphics    
BenchmarkSaveSTL-8     	       2	 538800719 ns/op	288716684 B/op	  547006 allocs/op
BenchmarkStreamSTL-8   	       2	 915093915 ns/op	67749084 B/op	  550130 allocs/op
PASS
coverage: 25.1% of statements
ok  	github.com/deadsy/sdfx/render	4.422s
```