### PR TITLE
Update README.md to include SDF Viewer Go as the replacement for SDFX-UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A simple CAD package written in Go (https://golang.org/)
  4. Preview the STL output in an STL viewer (e.g. http://www.meshlab.net/)
  5. Print the STL file if you like it enough.
 
-[SDFX-UI](https://github.com/Yeicor/sdfx-ui) allows faster development iterations, replacing steps 3 and 4 until the final build.
+[SDF Viewer Go](https://github.com/Yeicor/sdf-viewer-go) or [SDFX-UI](https://github.com/Yeicor/sdfx-ui) allow faster development iterations, replacing steps 3 and 4 until the final build.
 
 ## Why?
  * SDFs make CSG easy.


### PR DESCRIPTION
I am the author of both [SDFX-UI](https://github.com/Yeicor/sdfx-ui) and [SDF Viewer Go](https://github.com/Yeicor/sdf-viewer-go) and developed the latter as a much better replacement for SDFX-UI. As mentioned in SDFX-UI's readme:

> :warning: **This project is superseded by the [SDF Viewer](https://github.com/Yeicor/sdf-viewer) App with the [SDF Viewer Go](https://github.com/Yeicor/sdf-viewer-go) integration. The advantages of the new project are mainly the real-time rendering speed (GPU-accelerated), flexibility (easy to integrate with other languages and libraries), and even more features (parameter customization, custom procedural textures...).**

However, [SDF Viewer Go](https://github.com/Yeicor/sdf-viewer-go) depends on TinyGo (at least for now), which may not be able to compile all Go programs due to small implementation differences. In all other regards, SDF Viewer Go is strictly better than SDFX-UI, but I keep it in the README just in case someone's project is incompatible and still needs SDFX-UI to visualize the models. 