### PR TITLE
Remove go3mf transitive dependency from sdf package

### DIFF
--- a/render/3mf.go
+++ b/render/3mf.go
@@ -62,9 +62,9 @@ func Write3MF(wg *sync.WaitGroup, path string) (chan<- []*Triangle3, error) {
 		// read triangles from the channel and add them to the model
 		for ts := range c {
 			for _, t := range ts {
-				v1 := mb.AddVertex(conv.V3ToPoint3D(t.V[0]))
-				v2 := mb.AddVertex(conv.V3ToPoint3D(t.V[1]))
-				v3 := mb.AddVertex(conv.V3ToPoint3D(t.V[2]))
+				v1 := mb.AddVertex(V3ToPoint3D(t.V[0]))
+				v2 := mb.AddVertex(V3ToPoint3D(t.V[1]))
+				v3 := mb.AddVertex(V3ToPoint3D(t.V[2]))
 				mesh.Triangles.Triangle = append(mesh.Triangles.Triangle, go3mf.Triangle{V1: v1, V2: v2, V3: v3})
 			}
 		}
@@ -76,6 +76,11 @@ func Write3MF(wg *sync.WaitGroup, path string) (chan<- []*Triangle3, error) {
 	}()
 
 	return c, nil
+}
+
+// V3ToPoint3D converts a 3D float vector to a go3mf 3D vector.
+func V3ToPoint3D(a v3.Vec) go3mf.Point3D {
+	return go3mf.Point3D{float32(a.X), float32(a.Y), float32(a.Z)}
 }
 
 //-----------------------------------------------------------------------------

--- a/vec/conv/conv.go
+++ b/vec/conv/conv.go
@@ -16,7 +16,6 @@ import (
 	"github.com/deadsy/sdfx/vec/v2i"
 	v3 "github.com/deadsy/sdfx/vec/v3"
 	"github.com/deadsy/sdfx/vec/v3i"
-	"github.com/hpinc/go3mf"
 )
 
 //-----------------------------------------------------------------------------
@@ -59,11 +58,6 @@ func V2ToV2i(a v2.Vec) v2i.Vec {
 // V3ToV3i converts a 3D float vector to a 3D integer vector.
 func V3ToV3i(a v3.Vec) v3i.Vec {
 	return v3i.Vec{int(a.X), int(a.Y), int(a.Z)}
-}
-
-// V3ToPoint3D converts a 3D float vector to a go3mf 3D vector.
-func V3ToPoint3D(a v3.Vec) go3mf.Point3D {
-	return go3mf.Point3D{float32(a.X), float32(a.Y), float32(a.Z)}
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
I moved the vector conversion function for go3mf points to the render package (`render/3mf.go`), as it is the only place that uses this function.

This is needed to build a project that only uses the sdf package with TinyGo, as TinyGo does not support the `encoding/xml` package that go3mf depends upon. I need this for https://github.com/Yeicor/sdf-viewer-go to work.