### PR TITLE
FE - Finite Elements

### DIFF
--- a/render/fe.go
+++ b/render/fe.go
@@ -1,0 +1,9 @@
+package render
+
+import v3 "github.com/deadsy/sdfx/vec/v3"
+
+// Tetrahedron is a 3D tetrahedron.
+// https://en.wikipedia.org/wiki/Tetrahedron
+type Tetrahedron struct {
+	V [4]v3.Vec
+}

--- a/render/fewrite.go
+++ b/render/fewrite.go
@@ -1,0 +1,33 @@
+package render
+
+import (
+	"os"
+	"sync"
+)
+
+// writeFE writes a stream of finite elements in the shape of tetrahedra to an ABAQUS or CalculiX file.
+func writeFE(wg *sync.WaitGroup, path string) (chan<- []*Tetrahedron, error) {
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// External code writes triangles to this channel.
+	// This goroutine reads the channel and writes triangles to the file.
+	c := make(chan []*Tetrahedron)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer f.Close()
+
+		// read finite elements from the channel and write them to the file
+		for ts := range c {
+			for _, t := range ts {
+				_ = t
+			}
+		}
+	}()
+
+	return c, nil
+}

--- a/render/render.go
+++ b/render/render.go
@@ -52,6 +52,31 @@ func ToTriangles(
 
 //-----------------------------------------------------------------------------
 
+// ToFE renders an SDF3 to finite elements in the shape of tetrahedra.
+// Finite elements would then be written to an ABAQUS or CalculiX input file.
+func ToFE(
+	s sdf.SDF3, // sdf3 to render
+	path string, // path to filename
+	r Render3, // rendering method
+) {
+	fmt.Printf("rendering %s (%s)\n", path, r.Info(s))
+	// write the finite elements to an ABAQUS or CalculiX file
+	var wg sync.WaitGroup
+	output, err := writeFE(&wg, path)
+	if err != nil {
+		fmt.Printf("%s", err)
+		return
+	}
+	// run the renderer
+	r.Render(s, output)
+	// stop the FE writer reading on the channel
+	close(output)
+	// wait for the file write to complete
+	wg.Wait()
+}
+
+//-----------------------------------------------------------------------------
+
 // ToSTL renders an SDF3 to an STL file.
 func ToSTL(
 	s sdf.SDF3, // sdf3 to render


### PR DESCRIPTION
# Objective

Render an SDF3 to finite elements in the shape of [tetrahedra](https://en.wikipedia.org/wiki/Tetrahedron).

# Philosohpy / why

There are some commercial software to convert STL *surface* mesh to FEA *volume* mesh. Like [WELSIM](https://youtu.be/ofl1w1lPErU). But as far as I tested, they are unreliable, limited, slow, ...

## Problem

I have been only able to do STL mesh to FEA mesh conversion for WELSIM's own sample STL files like the following `hinge.stl` sample. For any other STL file, the conversion is throwing errors. Looks like even the commercial apps only work for perfect STL meshes without any fault. Not sure, maybe?

### STL *surface* mesh

![Screenshot_20230221_110954](https://user-images.githubusercontent.com/17475482/220280156-599eac54-8c7c-463c-aba9-3b626c1dc8c6.png)


### FEA *volume* mesh

![Screenshot_20230221_111047](https://user-images.githubusercontent.com/17475482/220280206-46878c23-062b-4f08-8815-bf8942f7c6de.png)

# Methodology

This looks like a feasible approach:

STL triangles `->` SDF3 `->` MT (marching tetrahedra) -> FE (finite elements) -> ABAQUS or CalculiX file

[Marching cubes](https://en.wikipedia.org/wiki/Marching_cubes) algorithm and [marching tetrahedra](https://en.wikipedia.org/wiki/Marching_tetrahedra) are closely related.

It's needed to develop a code like below. But for marching *tetrahedra* rather than marching *cubes*:

https://github.com/deadsy/sdfx/blob/5bd4805907429608b176ed6ddabe7063e48e87f3/render/march3.go#L4

* The above code extracts a triangle [isosurface](https://en.wikipedia.org/wiki/Isosurface) with all the `0` values.
* We need a code to extract tetrahedra elements with all the *non-positive* `<=0` values.
   * *Non-positive* means 3D space on _and_ inside the surface geometry.

# Output API

Feeding the *finite elements* in the shape of tetrahedra - or any other shape - into the FEA engines could be done in various ways. But looks like the ABAQUS way makes sense. Popular opensource FEA engines like [CalculiX](https://github.com/calculix/ccx) are using it too.

# Question

Does the whole thing make sense? We need it. Maybe others would need it too :roll_eyes: 
