### PR TITLE
Render to triangles

### DIFF
--- a/examples/gyroid/main.go
+++ b/examples/gyroid/main.go
@@ -124,8 +124,10 @@ func main() {
 	if err != nil {
 		log.Fatalf("error: %s", err)
 	}
+	// Rendering to STL is fine:
 	render.ToSTL(s2, "gyroid_teapot.stl", render.NewMarchingCubesUniform(200))
 
+	// Rendering to triangles and then saving the STL, the output file is not as expected:
 	m2v := render.ToTriangles(s2, render.NewMarchingCubesUniform(200))
 	m2 := make([]*sdf.Triangle3, len(m2v))
 	for i, t := range m2v {

--- a/examples/gyroid/main.go
+++ b/examples/gyroid/main.go
@@ -125,6 +125,13 @@ func main() {
 		log.Fatalf("error: %s", err)
 	}
 	render.ToSTL(s2, "gyroid_teapot.stl", render.NewMarchingCubesUniform(200))
+
+	m2v := render.ToTriangles(s2, render.NewMarchingCubesUniform(200))
+	m2 := make([]*sdf.Triangle3, len(m2v))
+	for i, t := range m2v {
+		m2[i] = &t
+	}
+	render.SaveSTL("gyroid_teapot_mesh.stl", m2)
 }
 
 //-----------------------------------------------------------------------------

--- a/examples/gyroid/main.go
+++ b/examples/gyroid/main.go
@@ -124,10 +124,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("error: %s", err)
 	}
-	// Rendering to STL is fine:
+	// Rendering to STL directly:
 	render.ToSTL(s2, "gyroid_teapot.stl", render.NewMarchingCubesUniform(200))
-
-	// Rendering to triangles and then saving the STL, the output file is not as expected:
+	// Rendering to triangles and then saving the STL. The output file should be the same as before:
 	m2 := render.ToTriangles(s2, render.NewMarchingCubesUniform(200))
 	render.SaveSTL("gyroid_teapot_mesh.stl", m2)
 }

--- a/examples/gyroid/main.go
+++ b/examples/gyroid/main.go
@@ -128,11 +128,7 @@ func main() {
 	render.ToSTL(s2, "gyroid_teapot.stl", render.NewMarchingCubesUniform(200))
 
 	// Rendering to triangles and then saving the STL, the output file is not as expected:
-	m2v := render.ToTriangles(s2, render.NewMarchingCubesUniform(200))
-	m2 := make([]*sdf.Triangle3, len(m2v))
-	for i, t := range m2v {
-		m2[i] = &t
-	}
+	m2 := render.ToTriangles(s2, render.NewMarchingCubesUniform(200))
 	render.SaveSTL("gyroid_teapot_mesh.stl", m2)
 }
 

--- a/render/render.go
+++ b/render/render.go
@@ -35,8 +35,8 @@ type Render2 interface {
 func ToTriangles(
 	s sdf.SDF3, // sdf3 to render
 	r Render3, // rendering method
-) []sdf.Triangle3 {
-	triangles := make([]sdf.Triangle3, 0)
+) []*sdf.Triangle3 {
+	triangles := make([]*sdf.Triangle3, 0)
 	var wg sync.WaitGroup
 	// To write the triangles.
 	output := sdf.WriteTriangles(&wg, &triangles)

--- a/sdf/triangle3.go
+++ b/sdf/triangle3.go
@@ -104,7 +104,7 @@ func (t *Triangle3) rotateToXY() M44 {
 //-----------------------------------------------------------------------------
 
 // WriteTriangles writes a stream of triangles to a slice.
-func WriteTriangles(wg *sync.WaitGroup, triangles *[]Triangle3) chan<- []*Triangle3 {
+func WriteTriangles(wg *sync.WaitGroup, triangles *[]*Triangle3) chan<- []*Triangle3 {
 	// External code writes triangles to this channel.
 	// This goroutine reads the channel and appends the triangles to a slice.
 	c := make(chan []*Triangle3)
@@ -115,7 +115,7 @@ func WriteTriangles(wg *sync.WaitGroup, triangles *[]Triangle3) chan<- []*Triang
 		// read triangles from the channel and append them to the slice
 		for ts := range c {
 			for _, t := range ts {
-				*triangles = append(*triangles, *t)
+				*triangles = append(*triangles, t)
 			}
 		}
 	}()


### PR DESCRIPTION
# Reproduce

This PR tries to reproduce and debug a problem. The problem is that `render.ToSTL()` works fine. However, `render.ToTriangles()` is problematic. This problem is just introduced recently.