### PR TITLE
Lipschitz gyroid

### DIFF
--- a/render/gyroid_test.go
+++ b/render/gyroid_test.go
@@ -14,8 +14,28 @@ import (
 // (|sdf(center)| ≥ half-diagonal) then skips cubes that contain surface,
 // producing holes. The fix divides Evaluate by √3·max(kᵢ).
 //
-// Gyroid is infinite, so we intersect with a box to get a renderable
-// finite shape and assert the resulting mesh is watertight.
+// Gyroid is infinite, so we intersect with a finite shape to get a
+// renderable surface. Tests sweep:
+//   - isotropic vs. anisotropic vs. extreme-anisotropic scales
+//   - fine (high-frequency, kMax large) and coarse (large period) scales
+//   - several clipping shapes (box, sphere, rounded box) so the gyroid
+//     surface meets different boundary geometries
+
+// gyroidScales gives the matrix of scale configurations the σ_max
+// correction has to handle.
+var gyroidScales = []struct {
+	name  string
+	scale v3.Vec
+}{
+	{"isotropic_3", v3.Vec{X: 3, Y: 3, Z: 3}},         // moderate period
+	{"isotropic_2", v3.Vec{X: 2, Y: 2, Z: 2}},         // medium period
+	{"isotropic_1", v3.Vec{X: 1, Y: 1, Z: 1}},         // fine; kMax = 2π
+	{"isotropic_0.7", v3.Vec{X: 0.7, Y: 0.7, Z: 0.7}}, // very fine
+	{"isotropic_5", v3.Vec{X: 5, Y: 5, Z: 5}},         // coarse
+	{"aniso_2_3_4", v3.Vec{X: 2, Y: 3, Z: 4}},         // mild anisotropy
+	{"aniso_1_4_2", v3.Vec{X: 1, Y: 4, Z: 2}},         // x dominates kMax
+	{"aniso_extreme", v3.Vec{X: 0.5, Y: 5, Z: 1}},     // x = kMax (≈ 4π)
+}
 
 func Test_Gyroid3D_Watertight(t *testing.T) {
 	const cells = 80
@@ -23,16 +43,7 @@ func Test_Gyroid3D_Watertight(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cases := []struct {
-		name  string
-		scale v3.Vec
-	}{
-		{"isotropic_2", v3.Vec{X: 2, Y: 2, Z: 2}},
-		{"isotropic_3", v3.Vec{X: 3, Y: 3, Z: 3}},
-		{"anisotropic_2_3_4", v3.Vec{X: 2, Y: 3, Z: 4}},
-		{"fine_1", v3.Vec{X: 1, Y: 1, Z: 1}},
-	}
-	for _, c := range cases {
+	for _, c := range gyroidScales {
 		t.Run(c.name, func(t *testing.T) {
 			g, err := sdf.Gyroid3D(c.scale)
 			if err != nil {
@@ -41,6 +52,55 @@ func Test_Gyroid3D_Watertight(t *testing.T) {
 			// Gyroid has empty bbox; put the box first so Intersect3D's
 			// `s0.BoundingBox()` heuristic gives the box's bbox.
 			s := sdf.Intersect3D(box, g)
+			tris := CollectTriangles(s, NewMarchingCubesOctree(cells))
+			be := CountBoundaryEdges(tris)
+			if be != 0 {
+				t.Errorf("octree mesh has %d boundary edges (want 0); %d tris", be, len(tris))
+			}
+			t.Logf("%d tris, %d boundary edges", len(tris), be)
+		})
+	}
+}
+
+// Different clipping shapes produce different boundary geometries that
+// stress how the gyroid surface joins the clipping surface. A bbox bug
+// in either side would surface here.
+func Test_Gyroid3D_VariedClipping_Watertight(t *testing.T) {
+	const cells = 80
+	sphere, err := sdf.Sphere3D(5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	roundedBox, err := sdf.Box3D(v3.Vec{X: 10, Y: 6, Z: 6}, 0.5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cyl, err := sdf.Cylinder3D(8, 4, 0.3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name string
+		clip sdf.SDF3
+	}{
+		{"sphere_clip", sphere},
+		{"rounded_box_clip", roundedBox},
+		{"cylinder_clip", cyl},
+		// Difference of two boxes — non-convex clipping region.
+		{"shell_clip", func() sdf.SDF3 {
+			outer, _ := sdf.Box3D(v3.Vec{X: 10, Y: 10, Z: 10}, 0)
+			inner, _ := sdf.Box3D(v3.Vec{X: 6, Y: 6, Z: 6}, 0)
+			return sdf.Difference3D(outer, inner)
+		}()},
+	}
+	scale := v3.Vec{X: 2, Y: 2, Z: 2}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			g, err := sdf.Gyroid3D(scale)
+			if err != nil {
+				t.Fatal(err)
+			}
+			s := sdf.Intersect3D(c.clip, g)
 			tris := CollectTriangles(s, NewMarchingCubesOctree(cells))
 			be := CountBoundaryEdges(tris)
 			if be != 0 {

--- a/render/gyroid_test.go
+++ b/render/gyroid_test.go
@@ -1,0 +1,52 @@
+package render
+
+import (
+	"testing"
+
+	"github.com/deadsy/sdfx/sdf"
+	v3 "github.com/deadsy/sdfx/vec/v3"
+)
+
+// Gyroid3D is not a true SDF — its implicit function
+//   g(p) = sin(kx·x)·cos(ky·y) + sin(ky·y)·cos(kz·z) + sin(kz·z)·cos(kx·x)
+// has gradient up to √3·max(kᵢ), so unrescaled it overstates 3D distance
+// by that factor. The octree marching-cubes renderer's isEmpty pruning
+// (|sdf(center)| ≥ half-diagonal) then skips cubes that contain surface,
+// producing holes. The fix divides Evaluate by √3·max(kᵢ).
+//
+// Gyroid is infinite, so we intersect with a box to get a renderable
+// finite shape and assert the resulting mesh is watertight.
+
+func Test_Gyroid3D_Watertight(t *testing.T) {
+	const cells = 80
+	box, err := sdf.Box3D(v3.Vec{X: 10, Y: 10, Z: 10}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name  string
+		scale v3.Vec
+	}{
+		{"isotropic_2", v3.Vec{X: 2, Y: 2, Z: 2}},
+		{"isotropic_3", v3.Vec{X: 3, Y: 3, Z: 3}},
+		{"anisotropic_2_3_4", v3.Vec{X: 2, Y: 3, Z: 4}},
+		{"fine_1", v3.Vec{X: 1, Y: 1, Z: 1}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			g, err := sdf.Gyroid3D(c.scale)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Gyroid has empty bbox; put the box first so Intersect3D's
+			// `s0.BoundingBox()` heuristic gives the box's bbox.
+			s := sdf.Intersect3D(box, g)
+			tris := CollectTriangles(s, NewMarchingCubesOctree(cells))
+			be := CountBoundaryEdges(tris)
+			if be != 0 {
+				t.Errorf("octree mesh has %d boundary edges (want 0); %d tris", be, len(tris))
+			}
+			t.Logf("%d tris, %d boundary edges", len(tris), be)
+		})
+	}
+}

--- a/sdf/gyroid.go
+++ b/sdf/gyroid.go
@@ -10,26 +10,39 @@ https://en.wikipedia.org/wiki/Gyroid
 
 package sdf
 
-import v3 "github.com/deadsy/sdfx/vec/v3"
+import (
+	"math"
+
+	v3 "github.com/deadsy/sdfx/vec/v3"
+)
 
 //-----------------------------------------------------------------------------
 
 // GyroidSDF3 is a 3d gyroid.
 type GyroidSDF3 struct {
-	k v3.Vec // scaling factor
+	k          v3.Vec  // scaling factor
+	invStretch float64 // 1/Lipschitz; makes g a Lipschitz-1 scalar field
 }
 
 // Gyroid3D returns a 3d gyroid.
 func Gyroid3D(scale v3.Vec) (SDF3, error) {
+	k := v3.Vec{Tau / scale.X, Tau / scale.Y, Tau / scale.Z}
+	// Gyroid is not a true SDF. The implicit function
+	//   g(p) = sin(kx·x)·cos(ky·y) + sin(ky·y)·cos(kz·z) + sin(kz·z)·cos(kx·x)
+	// has gradient bounded in magnitude by √3·max(k_i) (tight for isotropic
+	// scales). Dividing by that constant gives a Lipschitz-1 scalar field
+	// with the same zero level set — safe for the octree's isEmpty skip.
+	kMax := math.Max(math.Max(math.Abs(k.X), math.Abs(k.Y)), math.Abs(k.Z))
 	return &GyroidSDF3{
-		k: v3.Vec{Tau / scale.X, Tau / scale.Y, Tau / scale.Z},
+		k:          k,
+		invStretch: 1 / (math.Sqrt(3) * kMax),
 	}, nil
 }
 
-// Evaluate returns the minimum distance to a 3d gyroid.
+// Evaluate returns the gyroid implicit function rescaled to Lipschitz-1.
 func (s *GyroidSDF3) Evaluate(p v3.Vec) float64 {
 	p = p.Mul(s.k)
-	return p.Sin().Dot(v3.Vec{p.Y, p.Z, p.X}.Cos())
+	return p.Sin().Dot(v3.Vec{p.Y, p.Z, p.X}.Cos()) * s.invStretch
 }
 
 // BoundingBox returns the bounding box for a 3d gyroid.


### PR DESCRIPTION
# Fix Gyroid3D Lipschitz under-correction

Fixes one of the bugs in #85.

## The bug

`Gyroid3D` returns the gyroid implicit function

```
g(p) = sin(kx·x)·cos(ky·y) + sin(ky·y)·cos(kz·z) + sin(kz·z)·cos(kx·x)
```

which is **not** a signed distance function — `|∇g|` is bounded by
`√3·max(kᵢ)` (tight for isotropic scales), not by 1. The octree
marching-cubes renderer treats `Evaluate` as a Lipschitz-1 distance
estimator and prunes cubes via `|sdf(center)| ≥ half-diagonal`. Because
`g` is up to `√3·max(kᵢ)` larger than the true distance, the pruning
rule wrongly skips cubes that contain the gyroid surface, producing
holes.

The uniform renderer is fine — it evaluates every cube — so the bug
only shows up under octree.

## The fix

`GyroidSDF3` grows an `invStretch float64` field set at construction:

```go
kMax := math.Max(math.Max(math.Abs(k.X), math.Abs(k.Y)), math.Abs(k.Z))
s.invStretch = 1 / (math.Sqrt(3) * kMax)
```

`Evaluate` multiplies its result by `invStretch`, producing a
Lipschitz-1 scalar field with the same zero level set — the gyroid
surface is unchanged, just the magnitudes scale down enough that
octree pruning becomes sound.

## Tests

`render/gyroid_test.go` clips the (infinite) gyroid with a 10×10×10
box and renders via the octree at 80 cells, asserting zero boundary
edges across four scale configurations:

- `isotropic_2`, `isotropic_3` — symmetric scales
- `anisotropic_2_3_4` — non-isotropic, exercises `kMax` selection
- `fine_1` — high-frequency case where `kMax` is large

All pass on macOS.

## Architecture-specific note

Same family of bug as the high-taper screw rendering issue from #84 —
non-1-Lipschitz SDF that the octree's `isEmpty` rule wrongly trusts.
The conservative `√3·max(kᵢ)` bound is loose enough to absorb 1-ulp
FMA/FTZ rounding differences between architectures, so this should
pass equally on x86_64 and Apple Silicon.
