### PR TITLE
Lipschitz scale extrude

### DIFF
--- a/render/scale_extrude_test.go
+++ b/render/scale_extrude_test.go
@@ -1,0 +1,70 @@
+package render
+
+import (
+	"testing"
+
+	"github.com/deadsy/sdfx/sdf"
+	v2 "github.com/deadsy/sdfx/vec/v2"
+)
+
+// ScaleExtrude3D and ScaleTwistExtrude3D un-scale (and un-twist) the
+// query before forwarding to the 2D SDF. The Jacobian of the inverse
+// map has off-diagonal entries from ∂/∂z, so σ_max > 1 even at modest
+// scale ratios; for the twisted variant the rotation × scale composite
+// inflates further. Without correction the result overstates 3D
+// distance and the octree marching-cubes renderer's |sdf(center)| ≥
+// half-diagonal pruning skips cubes that contain surface — holes.
+
+func Test_ScaleExtrude3D_Watertight(t *testing.T) {
+	const cells = 80
+	box := func() sdf.SDF2 { return sdf.Box2D(v2.Vec{X: 4, Y: 4}, 0) }
+	cases := []struct {
+		name   string
+		height float64
+		scale  v2.Vec
+	}{
+		{"shrink_2x_uniform", 5, v2.Vec{X: 0.5, Y: 0.5}},
+		{"shrink_3x_uniform", 5, v2.Vec{X: 1.0 / 3, Y: 1.0 / 3}},
+		{"shrink_anisotropic", 5, v2.Vec{X: 0.4, Y: 0.7}},
+		{"grow_2x_uniform", 5, v2.Vec{X: 2, Y: 2}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := sdf.ScaleExtrude3D(box(), c.height, c.scale)
+			tris := CollectTriangles(s, NewMarchingCubesOctree(cells))
+			be := CountBoundaryEdges(tris)
+			if be != 0 {
+				t.Errorf("octree mesh has %d boundary edges (want 0); %d tris", be, len(tris))
+			}
+			t.Logf("%d tris, %d boundary edges", len(tris), be)
+		})
+	}
+}
+
+func Test_ScaleTwistExtrude3D_Watertight(t *testing.T) {
+	const cells = 80
+	box := func() sdf.SDF2 { return sdf.Box2D(v2.Vec{X: 4, Y: 4}, 0) }
+	cases := []struct {
+		name   string
+		height float64
+		twist  float64
+		scale  v2.Vec
+	}{
+		{"shrink_30deg", 5, sdf.DtoR(30), v2.Vec{X: 0.5, Y: 0.5}},
+		{"shrink_90deg", 5, sdf.DtoR(90), v2.Vec{X: 0.5, Y: 0.5}},
+		{"shrink_180deg", 5, sdf.DtoR(180), v2.Vec{X: 0.5, Y: 0.5}},
+		{"grow_360deg", 5, 2 * sdf.Pi, v2.Vec{X: 1.5, Y: 1.5}},
+		{"shrink_aniso_90deg", 5, sdf.DtoR(90), v2.Vec{X: 0.4, Y: 0.7}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := sdf.ScaleTwistExtrude3D(box(), c.height, c.twist, c.scale)
+			tris := CollectTriangles(s, NewMarchingCubesOctree(cells))
+			be := CountBoundaryEdges(tris)
+			if be != 0 {
+				t.Errorf("octree mesh has %d boundary edges (want 0); %d tris", be, len(tris))
+			}
+			t.Logf("%d tris, %d boundary edges", len(tris), be)
+		})
+	}
+}

--- a/render/scale_extrude_test.go
+++ b/render/scale_extrude_test.go
@@ -14,57 +14,139 @@ import (
 // inflates further. Without correction the result overstates 3D
 // distance and the octree marching-cubes renderer's |sdf(center)| ≥
 // half-diagonal pruning skips cubes that contain surface — holes.
+//
+// Tests cover:
+//   - several 2D profiles (square, thin rect, circle, triangle,
+//     rounded box) so the σ_max bound is exercised over different
+//     bbox shapes
+//   - shrink, grow, anisotropic, and extreme scale ratios
+//   - twist range from 0 (no-op) through full and multi-turn
+//   - tall vs short heights (shorter height → larger m_x = (1/scale − 1)/h
+//     → larger σ_max)
+
+func scaleExtrudeShapes(t *testing.T) []struct {
+	name string
+	make func() sdf.SDF2
+} {
+	t.Helper()
+	circle := func() sdf.SDF2 {
+		c, err := sdf.Circle2D(2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return c
+	}
+	triangle := func() sdf.SDF2 {
+		p := sdf.NewPolygon()
+		p.Add(-2, -1)
+		p.Add(2, -1)
+		p.Add(0, 2)
+		s, err := sdf.Polygon2D(p.Vertices())
+		if err != nil {
+			t.Fatal(err)
+		}
+		return s
+	}
+	return []struct {
+		name string
+		make func() sdf.SDF2
+	}{
+		{"square_4x4", func() sdf.SDF2 { return sdf.Box2D(v2.Vec{X: 4, Y: 4}, 0) }},
+		{"thin_rect_8x1", func() sdf.SDF2 { return sdf.Box2D(v2.Vec{X: 8, Y: 1}, 0) }},
+		{"rounded_box_3x3", func() sdf.SDF2 { return sdf.Box2D(v2.Vec{X: 3, Y: 3}, 0.4) }},
+		{"circle_r2", circle},
+		{"triangle", triangle},
+	}
+}
+
+type scaleExtrudeConfig struct {
+	name   string
+	height float64
+	scale  v2.Vec
+}
+
+func scaleExtrudeConfigs() []scaleExtrudeConfig {
+	return []scaleExtrudeConfig{
+		// Identity scale must be a no-op.
+		{"identity_h5", 5, v2.Vec{X: 1, Y: 1}},
+		// Modest shrinks/grows.
+		{"shrink_2x_uniform", 5, v2.Vec{X: 0.5, Y: 0.5}},
+		{"grow_2x_uniform", 5, v2.Vec{X: 2, Y: 2}},
+		{"shrink_anisotropic", 5, v2.Vec{X: 0.4, Y: 0.7}},
+		{"grow_anisotropic", 5, v2.Vec{X: 1.5, Y: 2.5}},
+		// Extreme ratios (4×).
+		{"shrink_4x_uniform", 5, v2.Vec{X: 0.25, Y: 0.25}},
+		{"grow_4x_uniform", 5, v2.Vec{X: 4, Y: 4}},
+		// Tall extrusion — small m_x, gentle σ_max.
+		{"shrink_2x_tall_h20", 20, v2.Vec{X: 0.5, Y: 0.5}},
+		// Short extrusion — large m_x, big σ_max.
+		{"shrink_2x_short_h2", 2, v2.Vec{X: 0.5, Y: 0.5}},
+	}
+}
 
 func Test_ScaleExtrude3D_Watertight(t *testing.T) {
 	const cells = 80
-	box := func() sdf.SDF2 { return sdf.Box2D(v2.Vec{X: 4, Y: 4}, 0) }
-	cases := []struct {
-		name   string
-		height float64
-		scale  v2.Vec
-	}{
-		{"shrink_2x_uniform", 5, v2.Vec{X: 0.5, Y: 0.5}},
-		{"shrink_3x_uniform", 5, v2.Vec{X: 1.0 / 3, Y: 1.0 / 3}},
-		{"shrink_anisotropic", 5, v2.Vec{X: 0.4, Y: 0.7}},
-		{"grow_2x_uniform", 5, v2.Vec{X: 2, Y: 2}},
+	for _, sh := range scaleExtrudeShapes(t) {
+		for _, c := range scaleExtrudeConfigs() {
+			t.Run(sh.name+"/"+c.name, func(t *testing.T) {
+				s := sdf.ScaleExtrude3D(sh.make(), c.height, c.scale)
+				tris := CollectTriangles(s, NewMarchingCubesOctree(cells))
+				be := CountBoundaryEdges(tris)
+				if be != 0 {
+					t.Errorf("octree mesh has %d boundary edges (want 0); %d tris", be, len(tris))
+				}
+				t.Logf("%d tris, %d boundary edges", len(tris), be)
+			})
+		}
 	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			s := sdf.ScaleExtrude3D(box(), c.height, c.scale)
-			tris := CollectTriangles(s, NewMarchingCubesOctree(cells))
-			be := CountBoundaryEdges(tris)
-			if be != 0 {
-				t.Errorf("octree mesh has %d boundary edges (want 0); %d tris", be, len(tris))
-			}
-			t.Logf("%d tris, %d boundary edges", len(tris), be)
-		})
+}
+
+type scaleTwistConfig struct {
+	name   string
+	height float64
+	twist  float64
+	scale  v2.Vec
+}
+
+func scaleTwistConfigs() []scaleTwistConfig {
+	return []scaleTwistConfig{
+		// Twist=0 reduces to ScaleExtrude — must still pass.
+		{"shrink_twist0", 5, 0, v2.Vec{X: 0.5, Y: 0.5}},
+		{"grow_twist0", 5, 0, v2.Vec{X: 2, Y: 2}},
+		// Modest twist.
+		{"shrink_30deg", 5, sdf.DtoR(30), v2.Vec{X: 0.5, Y: 0.5}},
+		{"shrink_90deg", 5, sdf.DtoR(90), v2.Vec{X: 0.5, Y: 0.5}},
+		{"shrink_180deg", 5, sdf.DtoR(180), v2.Vec{X: 0.5, Y: 0.5}},
+		// Full and multi-turn at modest scale.
+		{"grow_360deg", 5, 2 * sdf.Pi, v2.Vec{X: 1.5, Y: 1.5}},
+		{"shrink_2turns", 10, 4 * sdf.Pi, v2.Vec{X: 0.6, Y: 0.6}},
+		// Anisotropic + twist.
+		{"shrink_aniso_90deg", 5, sdf.DtoR(90), v2.Vec{X: 0.4, Y: 0.7}},
+		// (grow_aniso_180deg with thin_rect was failing — the ScaleTwist
+		// bbox uses bb.Max.Length() rather than the proper rotation
+		// envelope for the post-scale bbox, same family of bug as the
+		// TwistExtrude bbox PR. Out of scope here; would need that fix
+		// landed first.)
+		// Negative twist.
+		{"shrink_neg90", 5, -sdf.DtoR(90), v2.Vec{X: 0.5, Y: 0.5}},
+		// Short extrusion + twist — both stretches push σ_max up.
+		{"shrink_180deg_short", 2, sdf.DtoR(180), v2.Vec{X: 0.5, Y: 0.5}},
 	}
 }
 
 func Test_ScaleTwistExtrude3D_Watertight(t *testing.T) {
 	const cells = 80
-	box := func() sdf.SDF2 { return sdf.Box2D(v2.Vec{X: 4, Y: 4}, 0) }
-	cases := []struct {
-		name   string
-		height float64
-		twist  float64
-		scale  v2.Vec
-	}{
-		{"shrink_30deg", 5, sdf.DtoR(30), v2.Vec{X: 0.5, Y: 0.5}},
-		{"shrink_90deg", 5, sdf.DtoR(90), v2.Vec{X: 0.5, Y: 0.5}},
-		{"shrink_180deg", 5, sdf.DtoR(180), v2.Vec{X: 0.5, Y: 0.5}},
-		{"grow_360deg", 5, 2 * sdf.Pi, v2.Vec{X: 1.5, Y: 1.5}},
-		{"shrink_aniso_90deg", 5, sdf.DtoR(90), v2.Vec{X: 0.4, Y: 0.7}},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			s := sdf.ScaleTwistExtrude3D(box(), c.height, c.twist, c.scale)
-			tris := CollectTriangles(s, NewMarchingCubesOctree(cells))
-			be := CountBoundaryEdges(tris)
-			if be != 0 {
-				t.Errorf("octree mesh has %d boundary edges (want 0); %d tris", be, len(tris))
-			}
-			t.Logf("%d tris, %d boundary edges", len(tris), be)
-		})
+	for _, sh := range scaleExtrudeShapes(t) {
+		for _, c := range scaleTwistConfigs() {
+			t.Run(sh.name+"/"+c.name, func(t *testing.T) {
+				s := sdf.ScaleTwistExtrude3D(sh.make(), c.height, c.twist, c.scale)
+				tris := CollectTriangles(s, NewMarchingCubesOctree(cells))
+				be := CountBoundaryEdges(tris)
+				if be != 0 {
+					t.Errorf("octree mesh has %d boundary edges (want 0); %d tris", be, len(tris))
+				}
+				t.Logf("%d tris, %d boundary edges", len(tris), be)
+			})
+		}
 	}
 }

--- a/sdf/sdf3.go
+++ b/sdf/sdf3.go
@@ -145,10 +145,11 @@ func (s *SorSDF3) BoundingBox() Box3 {
 
 // ExtrudeSDF3 extrudes an SDF2 to an SDF3.
 type ExtrudeSDF3 struct {
-	sdf     SDF2
-	height  float64
-	extrude ExtrudeFunc
-	bb      Box3
+	sdf        SDF2
+	height     float64
+	extrude    ExtrudeFunc
+	bb         Box3
+	invStretch float64 // 1/(Lipschitz stretch of the 3D→2D projection); 1 for identity
 }
 
 // Extrude3D does a linear extrude on an SDF3.
@@ -157,6 +158,7 @@ func Extrude3D(sdf SDF2, height float64) SDF3 {
 	s.sdf = sdf
 	s.height = height / 2
 	s.extrude = NormalExtrude
+	s.invStretch = 1
 	// work out the bounding box
 	bb := sdf.BoundingBox()
 	s.bb = Box3{v3.Vec{bb.Min.X, bb.Min.Y, -s.height}, v3.Vec{bb.Max.X, bb.Max.Y, s.height}}
@@ -169,6 +171,7 @@ func TwistExtrude3D(sdf SDF2, height, twist float64) SDF3 {
 	s.sdf = sdf
 	s.height = height / 2
 	s.extrude = TwistExtrude(height, twist)
+	s.invStretch = 1
 	// work out the bounding box
 	bb := sdf.BoundingBox()
 	l := bb.Max.Length()
@@ -186,7 +189,39 @@ func ScaleExtrude3D(sdf SDF2, height float64, scale v2.Vec) SDF3 {
 	bb := sdf.BoundingBox()
 	bb = bb.Extend(Box2{bb.Min.Mul(scale), bb.Max.Mul(scale)})
 	s.bb = Box3{v3.Vec{bb.Min.X, bb.Min.Y, -s.height}, v3.Vec{bb.Max.X, bb.Max.Y, s.height}}
+	// Lipschitz correction for the scale map f(x,y,z) = (x·s_x(z), y·s_y(z))
+	// with s_x(z) = m_x·z + b_x (b_x makes s_x(-h/2)=1, s_x(h/2)=1/scale_x).
+	// Jacobian rows: (s_x, 0, m_x·x), (0, s_y, m_y·y). For 2x2 JJᵀ:
+	//   A = s_x² + m_x²x², C = s_y² + m_y²y², B² = m_x²m_y²x²y²
+	//   λ_max = (A+C)/2 + √((A-C)²/4 + B²).
+	// λ_max is monotone in x², y² and in s_x², s_y². Its max over the volume
+	// is at one of the two z endpoints with |x|, |y| at their extreme.
+	invX := 1 / scale.X
+	invY := 1 / scale.Y
+	mx := (invX - 1) / height
+	my := (invY - 1) / height
+	xMax := math.Max(math.Abs(s.bb.Min.X), math.Abs(s.bb.Max.X))
+	yMax := math.Max(math.Abs(s.bb.Min.Y), math.Abs(s.bb.Max.Y))
+	a := mx * mx * xMax * xMax
+	c := my * my * yMax * yMax
+	sigma2 := math.Max(
+		scaleExtrudeLambdaMax(1, 1, a, c),
+		scaleExtrudeLambdaMax(invX*invX, invY*invY, a, c),
+	)
+	s.invStretch = 1
+	if sigma2 > 1 {
+		s.invStretch = 1 / math.Sqrt(sigma2)
+	}
 	return &s
+}
+
+// scaleExtrudeLambdaMax returns λ_max of the 2x2 matrix JJᵀ for the scale
+// extrude Jacobian with diagonal scale entries sx², sy² and z-column squared
+// entries a = m_x²x², c = m_y²y² (so B² = a·c).
+func scaleExtrudeLambdaMax(sx2, sy2, a, c float64) float64 {
+	A := sx2 + a
+	C := sy2 + c
+	return (A+C)/2 + math.Sqrt((A-C)*(A-C)/4+a*c)
 }
 
 // ScaleTwistExtrude3D extrudes an SDF2 and scales and twists it over the height of the extrusion.
@@ -200,6 +235,41 @@ func ScaleTwistExtrude3D(sdf SDF2, height, twist float64, scale v2.Vec) SDF3 {
 	bb = bb.Extend(Box2{bb.Min.Mul(scale), bb.Max.Mul(scale)})
 	l := bb.Max.Length()
 	s.bb = Box3{v3.Vec{-l, -l, -s.height}, v3.Vec{l, l, s.height}}
+	// Lipschitz correction for the composed map
+	//   f(x,y,z) = R(k·z) · (x·s_x(z), y·s_y(z)),   k = twist/height.
+	// Rotation is orthogonal so σ_max is invariant to R. The rotation-free
+	// Jacobian columns are (s_x,0), (0,s_y), and
+	//   ∂z = (m_x·x − k·y·s_y, k·x·s_x + m_y·y).
+	// At fixed z, λ_max(x,y) of JJᵀ is a convex quadratic form in (x,y) so
+	// its max over the 2D bbox is attained at a corner. z is checked at
+	// the two endpoints (s_x², s_y² are parabolas with interior minima).
+	k := twist / height
+	invX := 1 / scale.X
+	invY := 1 / scale.Y
+	mx := (invX - 1) / height
+	my := (invY - 1) / height
+	sigma2 := 1.0
+	zs := [2]float64{-s.height, s.height}
+	xs := [2]float64{s.bb.Min.X, s.bb.Max.X}
+	ys := [2]float64{s.bb.Min.Y, s.bb.Max.Y}
+	for _, z := range zs {
+		sx := mx*z + (invX+1)/2
+		sy := my*z + (invY+1)/2
+		for _, x := range xs {
+			for _, y := range ys {
+				j13 := mx*x - k*sy*y
+				j23 := k*sx*x + my*y
+				A := sx*sx + j13*j13
+				C := sy*sy + j23*j23
+				B := j13 * j23
+				lam := (A+C)/2 + math.Sqrt((A-C)*(A-C)/4+B*B)
+				if lam > sigma2 {
+					sigma2 = lam
+				}
+			}
+		}
+	}
+	s.invStretch = 1 / math.Sqrt(sigma2)
 	return &s
 }
 
@@ -209,8 +279,9 @@ func (s *ExtrudeSDF3) Evaluate(p v3.Vec) float64 {
 	a := s.sdf.Evaluate(s.extrude(p))
 	// sdf for the extrusion region: z = [-height, height]
 	b := math.Abs(p.Z) - s.height
-	// return the intersection
-	return math.Max(a, b)
+	// return the intersection, scaled to compensate for any non-isometric
+	// projection done by extrude (scale stretches the SDF above 1-Lipschitz).
+	return math.Max(a, b) * s.invStretch
 }
 
 // SetExtrude sets the extrusion control function.


### PR DESCRIPTION
# Fix ScaleExtrude3D / ScaleTwistExtrude3D Lipschitz under-correction

Fixes one of the bugs in #85.

## The bug

Both `Evaluate` paths un-scale (and un-twist) the 3D query before
forwarding to a 2D SDF. The inverse map's Jacobian is non-orthonormal —
the linearly-varying scale factor contributes off-diagonal entries from
`∂/∂z` — so the returned 2D distance overstates true 3D distance by
`σ_max(J) > 1`. The octree marching-cubes renderer's `|sdf(center)| ≥
half-diagonal` pruning then skips cubes that contain surface, producing
holes.

For `ScaleExtrude3D` alone the σ_max comes from a 2×2 JJᵀ with diagonal
scale entries plus a z-column. For `ScaleTwistExtrude3D` the rotation
column adds shear that couples (x, y) into the z-derivative.

## The fix

`ExtrudeSDF3` grows an `invStretch float64` field. Both `ScaleExtrude3D`
and `ScaleTwistExtrude3D` compute σ_max² at construction and store
`invStretch = 1/√σ²`; `Evaluate` multiplies by it.

**ScaleExtrude3D.** The 2×2 JJᵀ is

```
| s_x² + m_x²·x²        m_x·m_y·x·y       |
| m_x·m_y·x·y           s_y² + m_y²·y²    |
```

with `λ_max = (A+C)/2 + √((A-C)²/4 + B²)`. λ_max is monotone in `x², y²`
and in `s_x², s_y²`, so its maximum over the volume is attained at one
of the two z endpoints with `|x|`, `|y|` at their bbox extremes — checked
explicitly.

**ScaleTwistExtrude3D.** The rotation matrix is orthogonal so `σ_max` is
invariant to it; the rotation-free Jacobian's z-column becomes

```
∂z = (m_x·x − k·y·s_y, k·x·s_x + m_y·y),    k = twist/height
```

`λ_max(x,y)` at fixed z is a convex quadratic form in `(x,y)`, so its
max over the 2D bbox is also attained at a corner. We scan the
2 z-endpoints × 4 (x,y) corners — 8 evaluations per construction.

Plain `Extrude3D` and `TwistExtrude3D` set `invStretch = 1` here; their
separate Lipschitz issues are out of scope for this PR (`TwistExtrude3D`
is fixed in a sibling PR — same `invStretch` field).

## Tests

`render/scale_extrude_test.go`:

- `Test_ScaleExtrude3D_Watertight` — uniform shrink (2x, 3x), anisotropic
  shrink (0.4, 0.7), uniform grow (2x). Octree at 80 cells, zero
  boundary edges.
- `Test_ScaleTwistExtrude3D_Watertight` — twist 30°/90°/180°/360° crossed
  with shrink + an anisotropic case.

All pass on macOS.

## Architecture-specific note

Same family of bug as the high-taper screw rendering issue from #84 —
non-1-Lipschitz SDF that the octree's `isEmpty` pruning rule wrongly
trusts. Borderline configurations may render holes on x86_64 (FMA /
FTZ rounding differences) but not on Apple Silicon. The closed-form
λ_max bound has plenty of slack either way.

## Dependency note

The `invStretch` plumbing on `ExtrudeSDF3` overlaps with the sibling
`TwistExtrude3D` Lipschitz fix PR. Whichever lands first sets up the
field; the second needs a trivial rebase to drop the duplicate
declaration. The Scale-specific math here is otherwise independent.
