### PR TITLE
Lipschitz loft

### DIFF
--- a/render/loft_test.go
+++ b/render/loft_test.go
@@ -1,0 +1,53 @@
+package render
+
+import (
+	"testing"
+
+	"github.com/deadsy/sdfx/sdf"
+	v2 "github.com/deadsy/sdfx/vec/v2"
+)
+
+// Loft3D linearly blends between two 2D SDFs along z. The xy gradient is
+// a convex combination of the two Lipschitz-1 inner gradients (so still
+// ≤ 1), but the z gradient grows with max|a1−a0|/(2·h_inner). The outer
+// d = √(a² + b²) end-cap composition further inflates the Lipschitz
+// constant. Without correction, the result overstates 3D distance and
+// the octree marching-cubes renderer's |sdf(center)| ≥ half-diagonal
+// pruning skips cubes that contain surface, producing holes.
+//
+// This test exercises the regime where the bug shows up: lofting
+// between two shapes of significantly different size (so max|a1−a0|
+// is substantial) with a short height (so L_z is large).
+
+func Test_Loft3D_Watertight(t *testing.T) {
+	const cells = 80
+	smallBox := func() sdf.SDF2 { return sdf.Box2D(v2.Vec{X: 1, Y: 1}, 0.1) }
+	bigBox := func() sdf.SDF2 { return sdf.Box2D(v2.Vec{X: 5, Y: 5}, 0.1) }
+	smallCircle := func() sdf.SDF2 { c, _ := sdf.Circle2D(0.5); return c }
+	bigCircle := func() sdf.SDF2 { c, _ := sdf.Circle2D(3); return c }
+	cases := []struct {
+		name          string
+		sdf0, sdf1    func() sdf.SDF2
+		height, round float64
+	}{
+		{"small_to_big_box_h2", smallBox, bigBox, 2, 0},
+		{"small_to_big_box_h5", smallBox, bigBox, 5, 0.05},
+		{"box_to_circle", bigBox, bigCircle, 5, 0.05},
+		{"circle_to_circle_growing", smallCircle, bigCircle, 3, 0.05},
+		{"circle_to_circle_short", smallCircle, bigCircle, 1, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s, err := sdf.Loft3D(c.sdf0(), c.sdf1(), c.height, c.round)
+			if err != nil {
+				t.Fatal(err)
+			}
+			tris := CollectTriangles(s, NewMarchingCubesOctree(cells))
+			be := CountBoundaryEdges(tris)
+			if be != 0 {
+				t.Errorf("octree mesh has %d boundary edges (want 0); %d tris", be, len(tris))
+			}
+			t.Logf("%d tris, %d boundary edges", len(tris), be)
+		})
+	}
+}

--- a/render/loft_test.go
+++ b/render/loft_test.go
@@ -1,6 +1,7 @@
 package render
 
 import (
+	"math"
 	"testing"
 
 	"github.com/deadsy/sdfx/sdf"
@@ -10,35 +11,108 @@ import (
 // Loft3D linearly blends between two 2D SDFs along z. The xy gradient is
 // a convex combination of the two Lipschitz-1 inner gradients (so still
 // ≤ 1), but the z gradient grows with max|a1−a0|/(2·h_inner). The outer
-// d = √(a² + b²) end-cap composition further inflates the Lipschitz
-// constant. Without correction, the result overstates 3D distance and
+// d = √(a² + b²) end-cap composition inflates the Lipschitz constant
+// further. Without correction the result overstates 3D distance and
 // the octree marching-cubes renderer's |sdf(center)| ≥ half-diagonal
 // pruning skips cubes that contain surface, producing holes.
 //
-// This test exercises the regime where the bug shows up: lofting
-// between two shapes of significantly different size (so max|a1−a0|
-// is substantial) with a short height (so L_z is large).
+// Tests cover:
+//   - identity loft (sdf0 == sdf1) — must give Lipschitz unchanged
+//   - same-shape size change (small→big, big→small)
+//   - cross-shape lofts (box↔circle, triangle→circle, star)
+//   - extreme size ratios
+//   - extreme height ratios (short height → large L_z)
+//   - with and without rounding
+//   - thin shapes — narrower bbox stresses the L_z bound
+
+func loftShapes(t *testing.T) map[string]func() sdf.SDF2 {
+	t.Helper()
+	circle := func(r float64) func() sdf.SDF2 {
+		return func() sdf.SDF2 {
+			c, err := sdf.Circle2D(r)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return c
+		}
+	}
+	triangle := func() sdf.SDF2 {
+		p := sdf.NewPolygon()
+		p.Add(-2, -1)
+		p.Add(2, -1)
+		p.Add(0, 2)
+		s, err := sdf.Polygon2D(p.Vertices())
+		if err != nil {
+			t.Fatal(err)
+		}
+		return s
+	}
+	star := func() sdf.SDF2 {
+		// 5-point star with outer radius 2, inner radius 0.8.
+		p := sdf.NewPolygon()
+		for i := 0; i < 10; i++ {
+			r := 2.0
+			if i%2 == 1 {
+				r = 0.8
+			}
+			a := float64(i) * math.Pi / 5
+			p.Add(r*math.Cos(a), r*math.Sin(a))
+		}
+		s, err := sdf.Polygon2D(p.Vertices())
+		if err != nil {
+			t.Fatal(err)
+		}
+		return s
+	}
+	return map[string]func() sdf.SDF2{
+		"box_1x1":      func() sdf.SDF2 { return sdf.Box2D(v2.Vec{X: 1, Y: 1}, 0.1) },
+		"box_3x3":      func() sdf.SDF2 { return sdf.Box2D(v2.Vec{X: 3, Y: 3}, 0.1) },
+		"box_5x5":      func() sdf.SDF2 { return sdf.Box2D(v2.Vec{X: 5, Y: 5}, 0.1) },
+		"box_3x1_thin": func() sdf.SDF2 { return sdf.Box2D(v2.Vec{X: 3, Y: 1}, 0.05) },
+		"circle_r0.5":  circle(0.5),
+		"circle_r2":    circle(2),
+		"circle_r3":    circle(3),
+		"triangle":     triangle,
+		"star":         star,
+	}
+}
 
 func Test_Loft3D_Watertight(t *testing.T) {
 	const cells = 80
-	smallBox := func() sdf.SDF2 { return sdf.Box2D(v2.Vec{X: 1, Y: 1}, 0.1) }
-	bigBox := func() sdf.SDF2 { return sdf.Box2D(v2.Vec{X: 5, Y: 5}, 0.1) }
-	smallCircle := func() sdf.SDF2 { c, _ := sdf.Circle2D(0.5); return c }
-	bigCircle := func() sdf.SDF2 { c, _ := sdf.Circle2D(3); return c }
-	cases := []struct {
+	shapes := loftShapes(t)
+	type loftCase struct {
 		name          string
-		sdf0, sdf1    func() sdf.SDF2
+		sdf0, sdf1    string
 		height, round float64
-	}{
-		{"small_to_big_box_h2", smallBox, bigBox, 2, 0},
-		{"small_to_big_box_h5", smallBox, bigBox, 5, 0.05},
-		{"box_to_circle", bigBox, bigCircle, 5, 0.05},
-		{"circle_to_circle_growing", smallCircle, bigCircle, 3, 0.05},
-		{"circle_to_circle_short", smallCircle, bigCircle, 1, 0},
+	}
+	cases := []loftCase{
+		// Identity loft — sdf0 == sdf1, max|a1-a0| = 0, L_z = 0,
+		// invStretch = 1. Pin that this path is a no-op.
+		{"identity_box3", "box_3x3", "box_3x3", 5, 0.05},
+		{"identity_circle", "circle_r2", "circle_r2", 5, 0.05},
+		// Same-shape size change.
+		{"box_small_to_big_h5", "box_1x1", "box_5x5", 5, 0.05},
+		{"box_small_to_big_h2_short", "box_1x1", "box_5x5", 2, 0.05},
+		{"box_small_to_big_h0.5_extreme", "box_1x1", "box_5x5", 0.5, 0.02},
+		{"circle_growing_h3", "circle_r0.5", "circle_r3", 3, 0.05},
+		{"circle_growing_h1_short", "circle_r0.5", "circle_r3", 1, 0},
+		// Cross-shape lofts (topology change).
+		{"box_to_circle_h5", "box_5x5", "circle_r3", 5, 0.05},
+		{"circle_to_box_h5", "circle_r3", "box_5x5", 5, 0.05},
+		{"triangle_to_circle_h5", "triangle", "circle_r2", 5, 0.05},
+		// Star — non-convex, multiple convex hulls.
+		{"star_to_circle_h5", "star", "circle_r2", 5, 0.05},
+		{"box_to_star_h5", "box_3x3", "star", 5, 0.05},
+		// Extreme size ratios.
+		{"tiny_to_huge_circle_h5", "circle_r0.5", "circle_r3", 5, 0.05},
+		// Thin shape lofts — narrower bbox stresses the L_z bound.
+		{"thin_box_to_thin_box_h5", "box_3x1_thin", "box_3x1_thin", 5, 0.02},
+		// Larger rounding.
+		{"box_loft_with_rounding", "box_1x1", "box_5x5", 5, 0.2},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s, err := sdf.Loft3D(c.sdf0(), c.sdf1(), c.height, c.round)
+			s, err := sdf.Loft3D(shapes[c.sdf0](), shapes[c.sdf1](), c.height, c.round)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/sdf/sdf3.go
+++ b/sdf/sdf3.go
@@ -308,6 +308,7 @@ type LoftSDF3 struct {
 	height     float64
 	round      float64
 	bb         Box3
+	invStretch float64 // 1/(Lipschitz of the (a, b) → d combiner); 1 if no inflation
 }
 
 // Loft3D extrudes an SDF3 that transitions between two SDF2 shapes.
@@ -338,7 +339,41 @@ func Loft3D(sdf0, sdf1 SDF2, height, round float64) (SDF3, error) {
 	bb1 := sdf1.BoundingBox()
 	bb := bb0.Extend(bb1)
 	s.bb = Box3{v3.Vec{bb.Min.X, bb.Min.Y, -s.height}.SubScalar(round), v3.Vec{bb.Max.X, bb.Max.Y, s.height}.AddScalar(round)}
+	// Lipschitz correction. For a = Mix(a0, a1, k) with k = 0.5·z/h + 0.5
+	// (h = height/2 − round), the xy gradient is a convex combination of
+	// the two Lipschitz-1 inner gradients so Lip_xy ≤ 1; the z gradient is
+	// bounded by L_z = max|a1−a0|/(2h). The outer d = √(a² + b²) end-cap
+	// gives a Lipschitz factor of √(1 + L_z·(L_z + √(L_z² + 4))/2), which
+	// is ≥ √(1 + L_z²).
+	lz := maxAbsDifference(sdf0, sdf1, bb, 16) / (2 * s.height)
+	lend2 := 1 + lz*(lz+math.Sqrt(lz*lz+4))/2
+	s.invStretch = 1
+	if lend2 > 1 {
+		s.invStretch = 1 / math.Sqrt(lend2)
+	}
 	return &s, nil
+}
+
+// maxAbsDifference returns an upper bound on max|a0(p) − a1(p)| over bb by
+// sampling an n×n grid and adding a Lipschitz-2 between-samples safety term
+// (a0 − a1 is Lipschitz-2 since each sdf is Lipschitz-1).
+func maxAbsDifference(a0, a1 SDF2, bb Box2, n int) float64 {
+	maxDiff := 0.0
+	dx := bb.Max.X - bb.Min.X
+	dy := bb.Max.Y - bb.Min.Y
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			ti := float64(i) / float64(n-1)
+			tj := float64(j) / float64(n-1)
+			p := v2.Vec{bb.Min.X + dx*ti, bb.Min.Y + dy*tj}
+			d := math.Abs(a0.Evaluate(p) - a1.Evaluate(p))
+			if d > maxDiff {
+				maxDiff = d
+			}
+		}
+	}
+	halfDiag := math.Hypot(dx/float64(n-1), dy/float64(n-1)) / 2
+	return maxDiff + 2*halfDiag
 }
 
 // Evaluate returns the minimum distance to a loft extrusion.
@@ -371,7 +406,7 @@ func (s *LoftSDF3) Evaluate(p v3.Vec) float64 {
 			d = a
 		}
 	}
-	return d - s.round
+	return (d - s.round) * s.invStretch
 }
 
 // BoundingBox returns the bounding box for a loft extrusion.


### PR DESCRIPTION
# Fix Loft3D Lipschitz under-correction

Fixes one of the bugs in #85.

## The bug

`Loft3D` linearly interpolates between two 2D SDFs along z:

```
a = Mix(a0(x,y), a1(x,y), k),    k = 0.5·z/h + 0.5
b = |z| − h
d = √(a² + b²)    when outside both axes
```

The xy gradient of `a` is a convex combination of the two inner
Lipschitz-1 gradients (so still `≤ 1`), but the z gradient grows
with `max|a1 − a0| / (2·h_inner)` and the outer `d = √(a² + b²)`
end-cap composition inflates further. Without correction `Evaluate`
overstates 3D distance and the octree's `|sdf(center)| ≥ half-diagonal`
pruning skips cubes that contain surface, producing holes.

## The fix

`LoftSDF3` grows an `invStretch float64` field set at construction:

```go
L_z   = max|a1(p) − a0(p)|_{p ∈ bb} / (2·h_inner)
L_end² = 1 + L_z·(L_z + √(L_z² + 4))/2
s.invStretch = 1 / √L_end²       (clamped to ≤ 1)
```

The `L_end² ≥ √(1 + L_z²)` factor is the joint Lipschitz of the
`(a, b) → √(a² + b²)` end-cap composition.

`max|a1 − a0|` is sampled on a 16×16 xy grid plus a Lipschitz-2
between-samples safety term (`a0 − a1` is Lipschitz-2 since each
inner SDF is Lipschitz-1). This is conservative; in practice it's
within a few percent of the true max for typical input shapes.

`Evaluate` multiplies its result by `invStretch` so the SDF stays
Lipschitz-1.

## Tests

`render/loft_test.go`:

- `small_to_big_box_h2` / `small_to_big_box_h5` — Box2D(1×1) →
  Box2D(5×5), short and tall heights (short → larger L_z).
- `box_to_circle` — exercises a topology-changing loft.
- `circle_to_circle_growing` / `circle_to_circle_short` — same shape
  family, varying L_z by changing height.

All assert zero boundary edges from the octree at 80 cells. Pass on
macOS.

## Architecture-specific note

Same family of bug as the high-taper screw rendering issue from #84 —
non-1-Lipschitz SDF that the octree's `isEmpty` rule wrongly trusts.
Borderline configurations may render holes on x86_64 (FMA / FTZ
rounding differences) but not on Apple Silicon. The closed-form L_end
bound has plenty of slack either way.
